### PR TITLE
chore: updated github actions

### DIFF
--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: "Checkout Code"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Setup GitHub Pages"
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
       - name: "Upload Artifact"
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
-          path: "."
+          path: "./src"
 
       - name: "Deploy to GitHub Pages"
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Updated github actions to the latest versions.
- actions/checkout@v4
- actions/configure-pages@v5
- actions/upload-pages-artifact@v3
- actions/deploy-pages@v4

Also, updated the path for the artifact upload to "./src".