### PR TITLE
fix: correct hero image path in CSS

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -56,7 +56,7 @@ img {
 }
 
 .hero {
-  background: url("assets/images/hero.jpg") no-repeat center center/cover;
+  background: url("../assets/images/hero.jpg") no-repeat center center/cover;
   height: 90vh;
   display: flex;
   justify-content: center;


### PR DESCRIPTION
The hero image path in `style.css` was incorrect after the project restructuring. This commit updates the path to `../assets/images/hero.jpg` to correctly point to the image location.