### PR TITLE
feat: implement travel stories page

### DIFF
--- a/src/stories.html
+++ b/src/stories.html
@@ -3,7 +3,59 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>Travel Stories - TravelEase</title>
+    <link rel="stylesheet" href="css/style.css" />
   </head>
-  <body></body>
+  <body>
+    <header>
+      <nav class="navbar">
+        <a href="index.html" class="logo">TravelEase</a>
+        <ul class="nav-links">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About Us</a></li>
+          <li><a href="destinations.html">Destinations</a></li>
+          <li><a href="planning.html">Trip Planner</a></li>
+          <li><a href="stories.html">Travel Stories</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main class="page-main">
+      <h1>Travel Stories</h1>
+      <section class="stories-section">
+        <article class="story-card">
+          <img
+            src="assets/images/fairy-meadows.jpg"
+            alt="Trek to Fairy Meadows"
+          />
+          <div class="story-content">
+            <h2>My Trek to Fairy Meadows</h2>
+            <p class="story-meta">By John Doe | Date: Aug 15, 2024</p>
+            <p class="story-preview">
+              The jeep ride was just the beginning of an adventure that led to
+              one of the most magical places on Earth. Waking up to the sight of
+              Nanga Parbat was a spiritual experience...
+            </p>
+            <a href="#" class="read-more">Read Full Story</a>
+          </div>
+        </article>
+        <article class="story-card">
+          <img src="assets/images/hunza.jpg" alt="Culture of Hunza" />
+          <div class="story-content">
+            <h2>Exploring the Culture of Hunza</h2>
+            <p class="story-meta">By Jane Smith | Date: Sep 02, 2024</p>
+            <p class="story-preview">
+              Beyond the stunning landscapes, it was the people of Hunza who
+              truly captured my heart. Their warmth, resilience, and the taste
+              of freshly picked apricots are memories I'll cherish forever...
+            </p>
+            <a href="#" class="read-more">Read Full Story</a>
+          </div>
+        </article>
+      </section>
+    </main>
+    <footer>
+      <p>&copy; 2025 TravelEase. All Rights Reserved.</p>
+    </footer>
+  </body>
 </html>


### PR DESCRIPTION
This commit introduces the "Travel Stories" page with the following features:

- Added a new `stories.html` file with basic HTML structure, including header, main content, and footer.
- Implemented a navigation bar with links to other pages.
- Created a "Travel Stories" section with two sample story cards, each containing an image, title, meta information (author and date), a short preview, and a "Read More" link.
- Linked the stylesheet `style.css` to the page.
- Updated the page title to "Travel Stories - TravelEase".

CLOSES: #9