### PR TITLE
fix: correct stylesheet link in destinations.html

### DIFF
--- a/src/destinations.html
+++ b/src/destinations.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Destinations - TravelEase</title>
-    <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="styles/style.css" />
   </head>
   <body>
     <header>


### PR DESCRIPTION
The stylesheet link in `destinations.html` was incorrect. It referenced `css/style.css`, but the stylesheet is located in `styles/style.css`. This commit corrects the link to ensure the page is styled correctly.