### PR TITLE
feat: implement trip planning guide page

### DIFF
--- a/src/planning.html
+++ b/src/planning.html
@@ -3,7 +3,94 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>Trip Planning Guide - TravelEase</title>
+    <link rel="stylesheet" href="styles/style.css" />
   </head>
-  <body></body>
+  <body>
+    <header>
+      <nav class="navbar">
+        <a href="index.html" class="logo">TravelEase</a>
+        <ul class="nav-links">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About Us</a></li>
+          <li><a href="destinations.html">Destinations</a></li>
+          <li><a href="planning.html">Trip Planner</a></li>
+          <li><a href="stories.html">Travel Stories</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main class="page-main">
+      <h1>Trip Planning Guide</h1>
+      <section class="planning-section">
+        <h2>Practical Tips for Tourists</h2>
+        <h3>How to Travel</h3>
+        <p>
+          Travel options include public buses, private car hires, and rugged 4x4
+          jeeps for mountainous terrain. Hiring local guides is highly
+          recommended for trekking and exploring remote areas. [cite: 21]
+        </p>
+        <h3>Where to Stay</h3>
+        <p>
+          A range of accommodation is available, from luxury hotels in major
+          towns to cozy, family-run guest houses that offer an authentic local
+          experience. [cite: 21]
+        </p>
+        <h3>Budgeting Tips</h3>
+        <p>
+          Plan your budget by considering transport, accommodation, food, and
+          guide fees. Eating at local dhabas is cheaper and more authentic.
+          Travel in the off-season for lower prices.
+        </p>
+        <h3>Packing Essentials</h3>
+        <p>
+          Always pack in layers. Essential items include thermal wear, a
+          waterproof jacket, sturdy hiking boots, sunscreen, a first-aid kit,
+          and a power bank. [cite: 21]
+        </p>
+
+        <h2>Downloadable Guides</h2>
+        <div class="download-links">
+          <a
+            href="assets/documents/packing_checklist.pdf"
+            class="download-btn"
+            download
+            >Packing Checklist (PDF)</a
+          >
+          <a
+            href="assets/documents/urdu_phrases.pdf"
+            class="download-btn"
+            download
+            >Basic Urdu Phrases (PDF)</a
+          >
+          <a
+            href="assets/documents/safety_guide.pdf"
+            class="download-btn"
+            download
+            >Safety Guide (PDF)</a
+          >
+        </div>
+
+        <h2>Frequently Asked Questions (FAQ)</h2>
+        <div class="faq">
+          <h4>Is Wi-Fi available in the northern areas?</h4>
+          <p>
+            Wi-Fi is available in major hotels in towns like Hunza, Skardu, and
+            Naran but can be slow. Mobile data (especially SCOM) works in many
+            areas, but don't expect connectivity in remote valleys. [cite: 22]
+          </p>
+          <h4>Do I need to hire a guide?</h4>
+          <p>
+            For city exploration, a guide isn't necessary. However, for
+            trekking, understanding local culture, and navigating remote areas,
+            a certified local guide is invaluable for both safety and
+            experience. [cite: 22]
+          </p>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <p>&copy; 2025 TravelEase. All Rights Reserved.</p>
+    </footer>
+  </body>
 </html>


### PR DESCRIPTION
This commit introduces the "Trip Planning Guide" page with the following features:

- Added a new `planning.html` file with basic HTML structure, including header, main content, and footer.
- Implemented a navigation bar with links to other pages, consistent with other pages.
- Added sections for practical tips for tourists, including information on travel, accommodation, budgeting, and packing essentials.
- Included downloadable guides for a packing checklist, basic Urdu phrases, and a safety guide.
- Added a FAQ section addressing common questions about Wi-Fi availability and the necessity of hiring a guide.
- Linked the stylesheet `style.css` to the page.
- Updated the page title to "Trip Planning Guide - TravelEase".

CLOSES: #8 